### PR TITLE
Fix resume button dark mode styling

### DIFF
--- a/src/app/components/socials.tsx
+++ b/src/app/components/socials.tsx
@@ -32,14 +32,19 @@ export function Socials(){
 
     return(
         <div className="flex gap-10 justify-center items-center spacer-bottom ">
-            <a href='/AustinHuntResume.pdf' className={isDarkMode ? "transition-transform hover:scale-110 dark-resume-button" :"transition-transform hover:scale-110 resume-button"} target="_blank" rel="noopener noreferrer">
+            <a
+                href='/AustinHuntResume.pdf'
+                className="transition-transform hover:scale-110 resume-button"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
                 Resume
             </a>
             <a href="https://github.com/austinhunt818" className="transition-transform hover:scale-125">
                 <img src={isDarkMode ? "logos/github-mark-white.svg" : "logos/github-mark.svg"} alt="GitHub" className="h-12 w-12" />
             </a>
             <a href="https://www.linkedin.com/in/austin-hunt-0183342b4/" className="transition-transform hover:scale-125">
-                <img src="logos/linkedin.svg" alt="LinkedIn" className="h-12 w-12" /> 
+                <img src="logos/linkedin.svg" alt="LinkedIn" className="h-12 w-12" />
             </a>
         </div>
     );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,11 +7,10 @@
   --foreground: #171717;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+/* When the `.dark` class is applied to the HTML element, swap the color variables */
+html.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 @font-face {
@@ -27,17 +26,6 @@ body {
   color: var(--foreground);
   background: var(--background);
   font-family: Arial, Helvetica, sans-serif;
-}
-
-.dark-resume-button{
-  background-color: var(--foreground);
-  color: var(--background);
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 0.25rem;
-  cursor: pointer;
-  font-size: 1rem;
-  font-weight: bold;
 }
 
 .resume-button {


### PR DESCRIPTION
## Summary
- tie CSS color variables to the `html.dark` class so toggled dark mode updates colors
- simplify resume button styling in Socials component to use variable-driven `.resume-button`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a765a2e4b88320a31ae312fde26956