### PR TITLE
Ensure project and profile images scale on small screens

### DIFF
--- a/src/app/components/profile.tsx
+++ b/src/app/components/profile.tsx
@@ -12,18 +12,16 @@ export function Profile() {
             <p className="text-lg text-center sm:text-left">
                 In addition to software development, I also enjoy music. I play many intstruments, but by far the most notable is saxophone. I have gotten to perform for thousands of people with the Blue Thunder Marching Band at Boise State.
             </p>
-            <div className="flex justify-center">
+            <div className="flex flex-col sm:flex-row justify-center items-center gap-4">
                 <img
                     src="/images/btmb.jpeg"
                     alt="Austin Hunt"
-                    width={350}
-                    className=" border-2 border-gray-500 dark:border-gray-800"
+                    className="w-full sm:max-w-[350px] border-2 border-gray-500 dark:border-gray-800"
                 />
                 <img
                     src="/images/sax.jpg"
                     alt="Austin Hunt with Saxophone"
-                    width={550}
-                    className=" border-2 border-gray-500 dark:border-gray-800 ml-4"
+                    className="w-full sm:max-w-[550px] border-2 border-gray-500 dark:border-gray-800"
                 />
             </div>
             <p className="text-lg text-center sm:text-left">

--- a/src/app/components/projects.tsx
+++ b/src/app/components/projects.tsx
@@ -50,9 +50,9 @@ export function Projects() {
                     <img src='logos/docker.svg' alt='Docker' title='Docker' className="h-12 w-12 hover:brightness-150 transition-all"/>             
                 </div>
                 <div className="flex flex-col sm:flex-row gap-4 mb-4 items-center justify-center">
-                    <img src='screenshots/cowhub_owner.png' alt='Cowhub Project Screenshot' className='w-3/5 rounded-lg border-2 border-gray-500 dark:border-gray-300' />
+                    <img src='screenshots/cowhub_owner.png' alt='Cowhub Project Screenshot' className='w-full sm:w-3/5 rounded-lg border-2 border-gray-500 dark:border-gray-300' />
                     {/*TODO: Get a better screenshot of video playback*/}
-                    <img src='screenshots/cowhub_video.png' alt='Cowhub Project Screenshot' className='w-1/4 sm:h-auto rounded-lg border-2 border-gray-500 dark:border-gray-300' />
+                    <img src='screenshots/cowhub_video.png' alt='Cowhub Project Screenshot' className='w-full sm:w-1/4 sm:h-auto rounded-lg border-2 border-gray-500 dark:border-gray-300' />
                 </div>
                 <br></br>
                 <p className="text-lg text-center sm:text-left mb-4">
@@ -85,8 +85,8 @@ export function Projects() {
                 </div>
                 <br></br>
                 <div className="flex flex-col sm:flex-row gap-10 mb-4">
-                    <img src='screenshots/compose_screenshot.png' alt='Screenshot of composition interface' className='w-3/5 rounded-lg border-2 border-gray-500 dark:border-gray-300' />
-                    <div className="w-2/5">
+                    <img src='screenshots/compose_screenshot.png' alt='Screenshot of composition interface' className='w-full sm:w-3/5 rounded-lg border-2 border-gray-500 dark:border-gray-300' />
+                    <div className="w-full sm:w-2/5">
                         <p className="text-lg">
                             Jingle Composer is a web app that allows users to create and save short jingles. I built this app for my final project in my web development class. Being a musician, I wanted to make something interactive and related to music, so I thought a music composition app would be a good fit.
                         </p>
@@ -98,7 +98,7 @@ export function Projects() {
                 </div>
                 <br></br>
                 <div className="flex flex-col sm:flex-row gap-20 mb-4">
-                    <div className="w-2/5">
+                    <div className="w-full sm:w-2/5">
                         <p className="text-lg">
                             Using AWS&apos;s lambdas and dynamoDB, the app allows for the jingles to be saved, loaded, edited, and deleted. The songs are stored as a string, represented by a sequence of note names or dashes. This persistence allows users to come back and listen to jingles the made in the past, and edit them if they desire.
                         </p>
@@ -107,7 +107,7 @@ export function Projects() {
                             The audio portion of the app is handled by a package I found called <a href='https://github.com/danigb/smplr' className='text-blue-600 dark:text-blue-700 hover:underline'>smplr</a>. This package includes a collection of audio samples to use for the notes, as well as a simple interface for playback. Using the different samples, {/* Make sure to implement this feature before publishing */} the user can choose between different instruments, such as piano, guitar, and saxophone.
                         </p>
                     </div>
-                    <img src='screenshots/view-songs_screenshot.png' alt='Screenshot of jingle view and search screen' className='w-1/2 rounded-lg border-2 border-gray-500 dark:border-gray-300' />
+                    <img src='screenshots/view-songs_screenshot.png' alt='Screenshot of jingle view and search screen' className='w-full sm:w-1/2 rounded-lg border-2 border-gray-500 dark:border-gray-300' />
                 </div>
                 <h2 className="text-3xl font-semibold mb-2 self-center">
                      Try a <a href='https://jingle-composer.vercel.app/index.html' className="text-blue-600 dark:text-blue-400 hover:underline">demo</a>!


### PR DESCRIPTION
## Summary
- Make profile pictures stack and scale responsively
- Use dynamic width classes for project screenshots so they adapt to viewport size

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a8c13f75d0832082edc7cbc4e7ae89